### PR TITLE
Orb Partner Review

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -2,9 +2,13 @@ version: 2.1
 
 description: |
   Common CircleCI tasks for the Crystal programming language.
+  
+display:
+  home_url: https://crystal-lang.org/
+  source_url: https://github.com/manastech/crystal-circleci-orb
 
 executors:
-  docker:
+  default:
     description: |
       Use the official Crystal Docker image as executor.
     parameters:
@@ -121,7 +125,7 @@ jobs:
       executor:
         description: The executor to use for this job.
         type: executor
-        default: docker
+        default: default
       cache-key:
         default: shard.yml
         description: File to use as a shards cache checksum
@@ -164,7 +168,7 @@ examples:
           jobs:
             - crystal/test
       orbs:
-        crystal: manastech/crystal@0.3
+        crystal: manastech/crystal@x.y
       version: 2.1
 
   nightly:
@@ -181,7 +185,7 @@ examples:
                   name: crystal/docker
                   tag: nightly
       orbs:
-        crystal: manastech/crystal@0.3
+        crystal: manastech/crystal@x.y
       version: 2.1
 
   binary-dependencies:
@@ -196,7 +200,7 @@ examples:
                 pre-steps:
                   - run: apt-get update && apt-get install -y libsqlite3-dev
       orbs:
-        crystal: manastech/crystal@0.3
+        crystal: manastech/crystal@x.y
       version: 2.1
 
   external-services:
@@ -224,5 +228,5 @@ examples:
                       name: Waiting for service to start (check dockerize)
                       command: sleep 5
       orbs:
-        crystal: manastech/crystal@0.3
+        crystal: manastech/crystal@x.y
       version: 2.1


### PR DESCRIPTION
- Add display key with homepage and source url
- Rename "docker" executor to "default". Common among orbs to have a "default" executor and optionally provide additional executors for VMs if needed.
- Update versions listed in usage examples to x.y. Another common representation in orbs to ensure the user is not going to accidentally utilize an old orb version if the examples fall behind.

Ensure all parameters have detailed descriptions and publish your orb to version at least 1.0 for release.

Recommended: add "https://circleci.com/orbs/registry/orb/manastech/crystal" to the website header area in the git repo as well as adding the "circleci-orbs" topic.

Once the changes are published we can reconnect to move the partner process forward 👍